### PR TITLE
Replace pypiwin32 with pywin32

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-pypiwin32
-setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ python_requires = >=3.7
 packages = find:
 include_package_data = True
 install_requires = 
-    pypiwin32
+    pywin32
     setuptools
 [bdist_wheel]
 universal=1


### PR DESCRIPTION
pypiwin32 is deprecated and [doesn't work on Python3](https://sourceforge.net/p/pywin32/bugs/522/)