### PR TITLE
(IMPORTANT) Fixed error- WNDPROC return value cannot be converted to LRESULT Type…

### DIFF
--- a/win10toast_click/__init__.py
+++ b/win10toast_click/__init__.py
@@ -188,6 +188,7 @@ class ToastNotifier(object):
 
     def on_destroy(self, hwnd, msg, wparam, lparam):
         """Clean after notification ended.
+    
         :hwnd:
         :msg:
         :wparam:
@@ -197,6 +198,6 @@ class ToastNotifier(object):
         Shell_NotifyIcon(NIM_DELETE, nid)
         PostQuitMessage(0)
 
-        return None
+        return 0  # Explicitly return 0 to fix the error
 
         # !FIX: TypeError: 'tuple' object is not callable


### PR DESCRIPTION
The error "WNDPROC return value cannot be converted to LRESULT TypeError: WPARAM is simple, so must be an int object (got NoneType)" is occurring because the `on_destroy` method is not returning any value explicitly, and as a result, it returns `None` by default. However, in this case, `on_destroy` should return an integer value (`LRESULT`). To fix the issue, you can add `return 0` at the end of the `on_destroy` method to explicitly return 0.

Here's the modified `on_destroy` method:

```python
def on_destroy(self, hwnd, msg, wparam, lparam):
    """Clean after notification ended.

    :hwnd:
    :msg:
    :wparam:
    :lparam:
    """
    nid = (self.hwnd, 0)
    Shell_NotifyIcon(NIM_DELETE, nid)
    PostQuitMessage(0)

    return 0  # Explicitly return 0 to fix the error
```

With this change, the `on_destroy` method will now return an integer value (`LRESULT`) as expected, and the error should be resolved.